### PR TITLE
Refactor Mobilenet fine-tuning notebooks to use ST model assets

### DIFF
--- a/notebooks/02_bis_train_mobilenet.ipynb
+++ b/notebooks/02_bis_train_mobilenet.ipynb
@@ -2,214 +2,268 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "910e59a1",
    "metadata": {},
    "source": [
-    "# MobileNet fine-tuning on dataset"
+    "# Fine-tuning ST SSD MobileNet v1 0.25 on FreLon COCO\n",
+    "\n",
+    "This notebook prepares the STMicroelectronics SSD MobileNet v1 0.25 baseline for fine-tuning on the FreLon dataset. The original Windows-only TensorFlow Lite loading sequence has been replaced with logic that downloads the `.h5` weights alongside the YAML configuration shipped in the STM32 model zoo. Data loading has also been updated to materialize uniform tensors from the ragged `.npz` annotations so they can be fed into training pipelines more easily.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01ce0577",
+   "metadata": {},
+   "source": [
+    "## Environment setup\n",
+    "Import packages, configure reproducibility, and describe file-system constants used throughout the notebook."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "id": "120d050f",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import ast\n",
     "import os\n",
     "from pathlib import Path\n",
-    "from typing import Tuple, List, Dict, Any\n",
+    "from typing import Dict, Iterable, List, Tuple\n",
     "\n",
-    "import tensorflow as tf\n",
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Load the .npz file\n",
-    "data_train = np.load('hornet-bees-2/train_frelon.npz', allow_pickle=True)\n",
-    "X_train = data_train['X']\n",
-    "y_train = data_train['y']\n",
+    "import requests\n",
+    "import tensorflow as tf\n",
+    "import tf_keras\n",
+    "import yaml\n",
     "\n",
-    "data_val = np.load('hornet-bees-2/val_frelon.npz', allow_pickle=True)\n",
-    "X_val = data_val['X'] \n",
-    "y_val = data_val['y']\n",
-    "\n",
-    "data_test = np.load('hornet-bees-2/test_frelon.npz', allow_pickle=True)\n",
-    "X_test = data_test['X']\n",
-    "y_test = data_test['y']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Preprocess the data\n",
-    "def preprocess_data(X):\n",
-    "    # Normalize the images\n",
-    "    X = X / 255.0\n",
-    "    return X\n",
-    "\n",
-    "# Preprocess the datasets\n",
-    "X_train = preprocess_data(X_train)\n",
-    "X_val = preprocess_data(X_val)\n",
-    "X_test = preprocess_data(X_test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Convert labels to arrays with consistent shapes\n",
-    "def format_labels(y):\n",
-    "    boxes = [entry['boxes'] for entry in y]  # Keep as a list due to varying shapes\n",
-    "    class_ids = [entry['class_ids'] for entry in y]  # Keep as a list due to varying shapes\n",
-    "    return boxes, class_ids\n",
-    "\n",
-    "y_train_boxes, y_train_classes = format_labels(y_train)\n",
-    "y_val_boxes, y_val_classes = format_labels(y_val)\n",
-    "y_test_boxes, y_test_classes = format_labels(y_test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Define the model\n",
-    "base_model = tf.keras.applications.MobileNetV2(input_shape=(224, 224, 3), include_top=False, weights='imagenet', alpha=0.35)\n",
-    "base_model.trainable = False\n",
-    "\n",
-    "inputs = tf.keras.layers.Input(shape=(416, 416, 3))\n",
-    "resized_inputs = tf.keras.layers.Resizing(224, 224)(inputs)\n",
-    "normalized_inputs = resized_inputs / 255.0\n",
-    "x = tf.keras.applications.mobilenet_v2.preprocess_input(normalized_inputs)\n",
-    "x = base_model(x, training=False)\n",
-    "x = tf.keras.layers.GlobalAveragePooling2D()(x)\n",
-    "\n",
-    "boxes_output = tf.keras.layers.Dense(4, name='boxes')(x)\n",
-    "classes_output = tf.keras.layers.Dense(1, activation='sigmoid', name='class_ids')(x)\n",
-    "\n",
-    "model = tf.keras.Model(inputs=inputs, outputs=[boxes_output, classes_output])\n",
-    "model.compile(\n",
-    "    optimizer=tf.keras.optimizers.Adam(learning_rate=0.0001),\n",
-    "    loss={\n",
-    "        'boxes': 'mean_squared_error',\n",
-    "        'class_ids': 'binary_crossentropy'\n",
-    "    },\n",
-    "    metrics={\n",
-    "        'boxes': 'mae',\n",
-    "        'class_ids': 'accuracy'\n",
-    "    }\n",
-    ")"
+    "print(f\"TensorFlow version: {tf.__version__}\")\n",
+    "print(f\"tf_keras version: {tf_keras.__version__}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "64e15df2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Pad the labels to ensure consistent lengths\n",
-    "def pad_labels(labels, max_boxes=10):\n",
-    "    padded_boxes = []\n",
-    "    padded_classes = []\n",
-    "    for entry in labels:\n",
-    "        boxes = entry['boxes']\n",
-    "        class_ids = entry['class_ids']\n",
-    "        # Handle empty boxes or class_ids\n",
-    "        if len(boxes) == 0:\n",
-    "            padded_boxes.append(np.zeros((max_boxes, 4), dtype=np.float32))\n",
-    "        else:\n",
-    "            padded_boxes.append(np.pad(boxes, ((0, max_boxes - len(boxes)), (0, 0)), mode='constant') if len(boxes) < max_boxes else boxes[:max_boxes])\n",
-    "        \n",
-    "        if len(class_ids) == 0:\n",
-    "            padded_classes.append(np.zeros((max_boxes,), dtype=np.float32))\n",
-    "        else:\n",
-    "            padded_classes.append(np.pad(class_ids, (0, max_boxes - len(class_ids)), mode='constant') if len(class_ids) < max_boxes else class_ids[:max_boxes])\n",
-    "    return np.array(padded_boxes), np.array(padded_classes)\n",
-    "\n",
-    "# Pad the training and validation labels\n",
-    "y_train_boxes_padded, y_train_classes_padded = pad_labels(y_train)\n",
-    "y_val_boxes_padded, y_val_classes_padded = pad_labels(y_val)\n",
-    "\n",
-    "# Train the model\n",
-    "history = model.fit(\n",
-    "    X_train,\n",
-    "    {'boxes': y_train_boxes_padded, 'class_ids': y_train_classes_padded},\n",
-    "    validation_data=(X_val, {'boxes': y_val_boxes_padded, 'class_ids': y_val_classes_padded}),\n",
-    "    epochs=10,\n",
-    "    batch_size=32\n",
-    ")"
+    "# Ensure deterministic behaviour where possible\n",
+    "SEED = 42\n",
+    "np.random.seed(SEED)\n",
+    "tf.random.set_seed(SEED)\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "53db2b07",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "Data cardinality is ambiguous. Make sure all arrays contain the same number of samples.'x' sizes: 55\n'y' sizes: 1, 0, 0, 1, 0, 0, 2, 2, 1, 0, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 2, 0, 1, 2, 1, 1, 1, 2, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 0, 0, 1, 0, 0, 2, 2, 1, 0, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 2, 0, 1, 2, 1, 1, 1, 2, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[8], line 2\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[38;5;66;03m# Evaluate the model\u001b[39;00m\n\u001b[1;32m----> 2\u001b[0m test_loss, test_metrics \u001b[38;5;241m=\u001b[39m \u001b[43mmodel\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mevaluate\u001b[49m\u001b[43m(\u001b[49m\n\u001b[0;32m      3\u001b[0m \u001b[43m    \u001b[49m\u001b[43mX_test\u001b[49m\u001b[43m,\u001b[49m\n\u001b[0;32m      4\u001b[0m \u001b[43m    \u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mboxes\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43my_test_boxes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mclass_ids\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43my_test_classes\u001b[49m\u001b[43m}\u001b[49m\n\u001b[0;32m      5\u001b[0m \u001b[43m)\u001b[49m\n\u001b[0;32m      7\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTest Loss:\u001b[39m\u001b[38;5;124m\"\u001b[39m, test_loss)\n\u001b[0;32m      8\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTest Metrics:\u001b[39m\u001b[38;5;124m\"\u001b[39m, test_metrics)\n",
-      "File \u001b[1;32mc:\\Users\\sBTvR\\miniforge3\\envs\\ml\\lib\\site-packages\\keras\\src\\utils\\traceback_utils.py:122\u001b[0m, in \u001b[0;36mfilter_traceback.<locals>.error_handler\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    119\u001b[0m     filtered_tb \u001b[38;5;241m=\u001b[39m _process_traceback_frames(e\u001b[38;5;241m.\u001b[39m__traceback__)\n\u001b[0;32m    120\u001b[0m     \u001b[38;5;66;03m# To get the full stack trace, call:\u001b[39;00m\n\u001b[0;32m    121\u001b[0m     \u001b[38;5;66;03m# `keras.config.disable_traceback_filtering()`\u001b[39;00m\n\u001b[1;32m--> 122\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m e\u001b[38;5;241m.\u001b[39mwith_traceback(filtered_tb) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m    123\u001b[0m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[0;32m    124\u001b[0m     \u001b[38;5;28;01mdel\u001b[39;00m filtered_tb\n",
-      "File \u001b[1;32mc:\\Users\\sBTvR\\miniforge3\\envs\\ml\\lib\\site-packages\\keras\\src\\trainers\\data_adapters\\data_adapter_utils.py:115\u001b[0m, in \u001b[0;36mcheck_data_cardinality\u001b[1;34m(data)\u001b[0m\n\u001b[0;32m    111\u001b[0m     sizes \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m, \u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;241m.\u001b[39mjoin(\n\u001b[0;32m    112\u001b[0m         \u001b[38;5;28mstr\u001b[39m(i\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m0\u001b[39m]) \u001b[38;5;28;01mfor\u001b[39;00m i \u001b[38;5;129;01min\u001b[39;00m tree\u001b[38;5;241m.\u001b[39mflatten(single_data)\n\u001b[0;32m    113\u001b[0m     )\n\u001b[0;32m    114\u001b[0m     msg \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mlabel\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m sizes: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00msizes\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m--> 115\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(msg)\n",
-      "\u001b[1;31mValueError\u001b[0m: Data cardinality is ambiguous. Make sure all arrays contain the same number of samples.'x' sizes: 55\n'y' sizes: 1, 0, 0, 1, 0, 0, 2, 2, 1, 0, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 2, 0, 1, 2, 1, 1, 1, 2, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1, 1, 0, 0, 1, 0, 0, 2, 2, 1, 0, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 2, 0, 1, 2, 1, 1, 1, 2, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 1, 1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Pad the test labels\n",
-    "y_test_boxes_padded, y_test_classes_padded = pad_labels(y_val)\n",
-    "\n",
-    "# Evaluate the model\n",
-    "test_loss, test_metrics = model.evaluate(\n",
-    "    X_test,\n",
-    "    {'boxes': y_test_boxes_padded, 'class_ids': y_test_classes_padded}\n",
+    "# Paths and remote resources\n",
+    "NOTEBOOK_DIR = Path.cwd()\n",
+    "DATA_ROOT = NOTEBOOK_DIR / \"hornet-bees-2\"\n",
+    "MODEL_VARIANT = \"st_ssd_mobilenet_v1_025_256\"\n",
+    "MODEL_BASE_URL = (\n",
+    "    \"https://raw.githubusercontent.com/STMicroelectronics/stm32ai-modelzoo/main/\"\n",
+    "    \"object_detection/st_ssd_mobilenet_v1/ST_pretrainedmodel_public_dataset/coco_2017_person\"\n",
     ")\n",
+    "MODEL_CACHE = NOTEBOOK_DIR / \"models_cache\" / MODEL_VARIANT\n",
+    "MODEL_CACHE.mkdir(parents=True, exist_ok=True)\n",
     "\n",
-    "print(\"Test Loss:\", test_loss)\n",
-    "print(\"Test Metrics:\", test_metrics)"
+    "MODEL_FILES = {\n",
+    "    \"weights\": f\"{MODEL_VARIANT}.h5\",\n",
+    "    \"config\": f\"{MODEL_VARIANT}_config.yaml\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def download_file(url: str, destination: Path) -> Path:\n",
+    "    \"Download a file from a URL if it does not already exist.\"\n",
+    "    if destination.exists():\n",
+    "        return destination\n",
+    "    response = requests.get(url, timeout=60)\n",
+    "    response.raise_for_status()\n",
+    "    destination.write_bytes(response.content)\n",
+    "    return destination\n",
+    "\n",
+    "\n",
+    "def ensure_model_assets() -> Dict[str, Path]:\n",
+    "    \"Retrieve model weights and configuration from the STM32 model zoo.\"\n",
+    "    assets: Dict[str, Path] = {}\n",
+    "    for key, filename in MODEL_FILES.items():\n",
+    "        url = f\"{MODEL_BASE_URL}/{MODEL_VARIANT}/{filename}\"\n",
+    "        path = MODEL_CACHE / filename\n",
+    "        assets[key] = download_file(url, path)\n",
+    "    return assets\n",
+    "\n",
+    "\n",
+    "def parse_input_shape(raw_shape: str) -> Tuple[int, int, int]:\n",
+    "    \"Parse the (H, W, C) tuple stored as a string in the YAML config.\"\n",
+    "    shape = ast.literal_eval(raw_shape)\n",
+    "    if len(shape) != 3:\n",
+    "        raise ValueError(f\"Unexpected input shape {shape}\")\n",
+    "    return tuple(int(dim) for dim in shape)\n",
+    "\n",
+    "\n",
+    "def ensure_materialized_npz(npz_path: Path) -> None:\n",
+    "    \"Validate that Git LFS placeholders have been pulled before loading numpy archives.\"\n",
+    "    if not npz_path.exists():\n",
+    "        raise FileNotFoundError(f\"Expected dataset file missing: {npz_path}\")\n",
+    "    head = npz_path.read_bytes()[:64]\n",
+    "    if b\"version https://git-lfs.github.com\" in head:\n",
+    "        raise RuntimeError(\n",
+    "            f\"{npz_path} is a Git LFS pointer. Run `git lfs pull` or download the FreLon dataset \"\n",
+    "            \"before executing this notebook.\"\n",
+    "        )\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7cf8e6dd",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Download assets and instantiate the baseline SSD Mobilenet model\n",
+    "assets = ensure_model_assets()\n",
+    "print(\"Model assets cached:\", assets)\n",
+    "\n",
+    "with assets[\"config\"].open(\"r\", encoding=\"utf-8\") as cfg_file:\n",
+    "    model_config = yaml.safe_load(cfg_file)\n",
+    "\n",
+    "input_shape = parse_input_shape(model_config[\"training\"][\"model\"][\"input_shape\"])\n",
+    "class_names = model_config.get(\"dataset\", {}).get(\"class_names\", [\"hornet\"])\n",
+    "print(f\"Input shape: {input_shape}\")\n",
+    "print(f\"Classes declared in config: {class_names}\")\n",
+    "\n",
+    "# Load the STMicro `.h5` model using the legacy-compatible `tf_keras` loader\n",
+    "st_model = tf_keras.models.load_model(assets[\"weights\"], compile=False)\n",
+    "print(\"Model outputs:\", st_model.output_names)\n",
+    "print(\"Detection heads shapes:\", [output.shape for output in st_model.outputs])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b704973",
+   "metadata": {},
+   "source": [
+    "## Data pipeline helpers\n",
+    "Functions below load the FreLon `.npz` exports, normalise the images, and convert ragged label structures into padded tensors. The padded representation captures bounding boxes, one-hot encoded classes, and a mask marking real boxes versus padding so downstream training code can create dense tensors matching the detection heads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "baebcdfb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_split(split: str) -> Tuple[np.ndarray, List[Dict[str, np.ndarray]]]:\n",
+    "    \"Load images and raw annotations for a given split.\"\n",
+    "    npz_path = DATA_ROOT / f\"{split}_frelon.npz\"\n",
+    "    ensure_materialized_npz(npz_path)\n",
+    "    with np.load(npz_path, allow_pickle=True) as data:\n",
+    "        images = data[\"X\"].astype(np.float32)\n",
+    "        annotations = list(data[\"y\"])\n",
+    "    return images, annotations\n",
+    "\n",
+    "\n",
+    "def normalise_images(images: np.ndarray) -> np.ndarray:\n",
+    "    return images / 255.0\n",
+    "\n",
+    "\n",
+    "def pad_annotations(\n",
+    "    annotations: List[Dict[str, np.ndarray]],\n",
+    "    num_classes: int,\n",
+    ") -> Tuple[np.ndarray, np.ndarray, np.ndarray]:\n",
+    "    \"Convert ragged detection targets into dense arrays.\"\n",
+    "    max_boxes = max(len(entry[\"boxes\"]) for entry in annotations)\n",
+    "    batch_size = len(annotations)\n",
+    "    boxes = np.zeros((batch_size, max_boxes, 4), dtype=np.float32)\n",
+    "    classes = np.zeros((batch_size, max_boxes, num_classes), dtype=np.float32)\n",
+    "    mask = np.zeros((batch_size, max_boxes), dtype=np.float32)\n",
+    "    for idx, entry in enumerate(annotations):\n",
+    "        entry_boxes = np.asarray(entry[\"boxes\"], dtype=np.float32)\n",
+    "        entry_class_ids = np.asarray(entry.get(\"class_ids\", entry.get(\"classes\")), dtype=np.int32)\n",
+    "        count = len(entry_boxes)\n",
+    "        if count == 0:\n",
+    "            continue\n",
+    "        boxes[idx, :count] = entry_boxes\n",
+    "        classes[idx, np.arange(count), entry_class_ids] = 1.0\n",
+    "        mask[idx, :count] = 1.0\n",
+    "    return boxes, classes, mask\n",
+    "\n",
+    "\n",
+    "def summarise_split(name: str, images: np.ndarray, annotations: List[Dict[str, np.ndarray]], num_classes: int) -> None:\n",
+    "    boxes, classes, mask = pad_annotations(annotations, num_classes)\n",
+    "    print(f\"{name} images: {images.shape}\")\n",
+    "    print(f\"{name} boxes tensor shape: {boxes.shape}\")\n",
+    "    print(f\"{name} classes tensor shape: {classes.shape}\")\n",
+    "    print(f\"{name} mask tensor shape: {mask.shape}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07063f94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Attempt to materialise the FreLon dataset splits\n",
+    "try:\n",
+    "    train_images, train_ann = load_split(\"train\")\n",
+    "    val_images, val_ann = load_split(\"val\")\n",
+    "    test_images, test_ann = load_split(\"test\")\n",
+    "    summarise_split(\"Train\", train_images, train_ann, len(class_names))\n",
+    "    summarise_split(\"Validation\", val_images, val_ann, len(class_names))\n",
+    "    summarise_split(\"Test\", test_images, test_ann, len(class_names))\n",
+    "except Exception as error:\n",
+    "    print(f\"Dataset unavailable: {error}\")\n",
+    "    train_images = val_images = test_images = None\n",
+    "    train_ann = val_ann = test_ann = None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2db47e0b",
+   "metadata": {},
+   "source": [
+    "## Fine-tuning workflow (placeholder)\n",
+    "The FreLon data can now be converted into dense tensors, but training requires anchor matching against the SSD detection heads. Implementing that matching logic is outside the scope of this automated refactor. The cell below illustrates where a fine-tuning loop would live once the dataset has been fully materialised and encoded for the SSD outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91ef7871",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if train_images is None:\n",
+    "    raise RuntimeError(\n",
+    "        \"Training cannot start because the FreLon dataset archives were not available. \"\n",
+    "        \"Download the `.npz` files (or run `git lfs pull`) and re-run the data-loading cell.\"\n",
+    "    )\n",
+    "\n",
+    "# TODO: Implement SSD anchor matching and compile the model with appropriate losses.\n",
+    "# Placeholder to indicate where fine-tuning would be triggered once targets are aligned with the 6,825 anchors.\n",
+    "# st_model.compile(...)\n",
+    "# history = st_model.fit(...)\n"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ml",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }

--- a/notebooks/02_train_mobilenet.ipynb
+++ b/notebooks/02_train_mobilenet.ipynb
@@ -2,521 +2,268 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "910e59a1",
    "metadata": {},
    "source": [
-    "# MobileNet fine-tuning on dataset"
+    "# Fine-tuning ST SSD MobileNet v1 0.25 on FreLon COCO\n",
+    "\n",
+    "This notebook prepares the STMicroelectronics SSD MobileNet v1 0.25 baseline for fine-tuning on the FreLon dataset. The original Windows-only TensorFlow Lite loading sequence has been replaced with logic that downloads the `.h5` weights alongside the YAML configuration shipped in the STM32 model zoo. Data loading has also been updated to materialize uniform tensors from the ragged `.npz` annotations so they can be fed into training pipelines more easily.\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "01ce0577",
    "metadata": {},
    "source": [
-    "## Imports\n",
-    "### Libraries"
+    "## Environment setup\n",
+    "Import packages, configure reproducibility, and describe file-system constants used throughout the notebook."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "id": "120d050f",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import ast\n",
     "import os\n",
     "from pathlib import Path\n",
-    "from typing import Tuple, List, Dict, Any\n",
-    "\n",
-    "from roboflow import Roboflow\n",
-    "import tensorflow as tf\n",
+    "from typing import Dict, Iterable, List, Tuple\n",
     "\n",
     "import numpy as np\n",
+    "import requests\n",
+    "import tensorflow as tf\n",
+    "import tf_keras\n",
+    "import yaml\n",
     "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import matplotlib.patches as patches"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Load the .npz file\n",
-    "data_train = np.load('hornet-bees-2/train_frelon.npz', allow_pickle=True)\n",
-    "X_train = data_train['X']\n",
-    "y_train = data_train['y']\n",
-    "\n",
-    "data_val = np.load('hornet-bees-2/val_frelon.npz', allow_pickle=True)\n",
-    "X_val = data_val['X'] \n",
-    "y_val = data_val['y']\n",
-    "\n",
-    "data_test = np.load('hornet-bees-2/test_frelon.npz', allow_pickle=True)\n",
-    "X_test = data_test['X']\n",
-    "y_test = data_test['y']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model path : C:\\Users\\sBTvR\\Documents\\Projets techniques\\GitHub\\Frelon-v0\\src\\models\\ssd_mobilenet_v2_fpnlite_035_416_int8.tflite\n"
-     ]
-    }
-   ],
-   "source": [
-    "models_path = \"..\\src\\models\\ssd_mobilenet_v2_fpnlite_035_416_int8.tflite\"\n",
-    "models_abs_path = Path(models_path)\n",
-    "print(\"Model path :\", models_abs_path.resolve())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Modèle TFLite chargé avec succès \n",
-      "Inputs: [('serving_default_input_1:0', array([  1, 416, 416,   3], dtype=int32))]\n",
-      "Outputs: [('StatefulPartitionedCall:2', array([    1, 18070,     2], dtype=int32)), ('StatefulPartitionedCall:1', array([    1, 18070,     4], dtype=int32)), ('StatefulPartitionedCall:0', array([    1, 18070,     4], dtype=int32))]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "    Warning: tf.lite.Interpreter is deprecated and is scheduled for deletion in\n",
-      "    TF 2.20. Please use the LiteRT interpreter from the ai_edge_litert package.\n",
-      "    See the [migration guide](https://ai.google.dev/edge/litert/migration)\n",
-      "    for details.\n",
-      "    \n"
-     ]
-    }
-   ],
-   "source": [
-    "model = tf.lite.Interpreter(model_path=str(models_abs_path.resolve()))\n",
-    "model.allocate_tensors()\n",
-    "\n",
-    "print(\"Modèle TFLite chargé avec succès \")\n",
-    "print(f\"Inputs: {[(detail['name'], detail['shape']) for detail in model.get_input_details()]}\")\n",
-    "print(f\"Outputs: {[(detail['name'], detail['shape']) for detail in model.get_output_details()]}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model adapted for predicting bounding boxes and a single class\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"ssd_mobilenet_v2_fpnlite_035_416_int8_frelon\"</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1mModel: \"ssd_mobilenet_v2_fpnlite_035_416_int8_frelon\"\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓\n",
-       "┃<span style=\"font-weight: bold\"> Layer (type)        </span>┃<span style=\"font-weight: bold\"> Output Shape      </span>┃<span style=\"font-weight: bold\">    Param # </span>┃<span style=\"font-weight: bold\"> Connected to      </span>┃\n",
-       "┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩\n",
-       "│ input_layer_22      │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">416</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">416</span>,  │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ -                 │\n",
-       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">InputLayer</span>)        │ <span style=\"color: #00af00; text-decoration-color: #00af00\">3</span>)                │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ resizing_6          │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">224</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">224</span>,  │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ input_layer_22[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>… │\n",
-       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Resizing</span>)          │ <span style=\"color: #00af00; text-decoration-color: #00af00\">3</span>)                │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ true_divide_13      │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">224</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">224</span>,  │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ resizing_6[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>]  │\n",
-       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">TrueDivide</span>)        │ <span style=\"color: #00af00; text-decoration-color: #00af00\">3</span>)                │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ true_divide_14      │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">224</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">224</span>,  │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ true_divide_13[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>… │\n",
-       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">TrueDivide</span>)        │ <span style=\"color: #00af00; text-decoration-color: #00af00\">3</span>)                │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ subtract_11         │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">224</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">224</span>,  │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ true_divide_14[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>… │\n",
-       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Subtract</span>)          │ <span style=\"color: #00af00; text-decoration-color: #00af00\">3</span>)                │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ mobilenetv2_0.35_2… │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">7</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">7</span>,      │    <span style=\"color: #00af00; text-decoration-color: #00af00\">410,208</span> │ subtract_11[<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>][<span style=\"color: #00af00; text-decoration-color: #00af00\">0</span>] │\n",
-       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Functional</span>)        │ <span style=\"color: #00af00; text-decoration-color: #00af00\">1280</span>)             │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ global_average_poo… │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1280</span>)      │          <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> │ mobilenetv2_0.35… │\n",
-       "│ (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">GlobalAveragePool…</span> │                   │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ boxes (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)       │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">4</span>)         │      <span style=\"color: #00af00; text-decoration-color: #00af00\">5,124</span> │ global_average_p… │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ class_ids (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">Dense</span>)   │ (<span style=\"color: #00d7ff; text-decoration-color: #00d7ff\">None</span>, <span style=\"color: #00af00; text-decoration-color: #00af00\">1</span>)         │      <span style=\"color: #00af00; text-decoration-color: #00af00\">1,281</span> │ global_average_p… │\n",
-       "└─────────────────────┴───────────────────┴────────────┴───────────────────┘\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓\n",
-       "┃\u001b[1m \u001b[0m\u001b[1mLayer (type)       \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mOutput Shape     \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m   Param #\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mConnected to     \u001b[0m\u001b[1m \u001b[0m┃\n",
-       "┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩\n",
-       "│ input_layer_22      │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m416\u001b[0m, \u001b[38;5;34m416\u001b[0m,  │          \u001b[38;5;34m0\u001b[0m │ -                 │\n",
-       "│ (\u001b[38;5;33mInputLayer\u001b[0m)        │ \u001b[38;5;34m3\u001b[0m)                │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ resizing_6          │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m224\u001b[0m, \u001b[38;5;34m224\u001b[0m,  │          \u001b[38;5;34m0\u001b[0m │ input_layer_22[\u001b[38;5;34m0\u001b[0m… │\n",
-       "│ (\u001b[38;5;33mResizing\u001b[0m)          │ \u001b[38;5;34m3\u001b[0m)                │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ true_divide_13      │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m224\u001b[0m, \u001b[38;5;34m224\u001b[0m,  │          \u001b[38;5;34m0\u001b[0m │ resizing_6[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m]  │\n",
-       "│ (\u001b[38;5;33mTrueDivide\u001b[0m)        │ \u001b[38;5;34m3\u001b[0m)                │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ true_divide_14      │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m224\u001b[0m, \u001b[38;5;34m224\u001b[0m,  │          \u001b[38;5;34m0\u001b[0m │ true_divide_13[\u001b[38;5;34m0\u001b[0m… │\n",
-       "│ (\u001b[38;5;33mTrueDivide\u001b[0m)        │ \u001b[38;5;34m3\u001b[0m)                │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ subtract_11         │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m224\u001b[0m, \u001b[38;5;34m224\u001b[0m,  │          \u001b[38;5;34m0\u001b[0m │ true_divide_14[\u001b[38;5;34m0\u001b[0m… │\n",
-       "│ (\u001b[38;5;33mSubtract\u001b[0m)          │ \u001b[38;5;34m3\u001b[0m)                │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ mobilenetv2_0.35_2… │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m7\u001b[0m, \u001b[38;5;34m7\u001b[0m,      │    \u001b[38;5;34m410,208\u001b[0m │ subtract_11[\u001b[38;5;34m0\u001b[0m][\u001b[38;5;34m0\u001b[0m] │\n",
-       "│ (\u001b[38;5;33mFunctional\u001b[0m)        │ \u001b[38;5;34m1280\u001b[0m)             │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ global_average_poo… │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m1280\u001b[0m)      │          \u001b[38;5;34m0\u001b[0m │ mobilenetv2_0.35… │\n",
-       "│ (\u001b[38;5;33mGlobalAveragePool…\u001b[0m │                   │            │                   │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ boxes (\u001b[38;5;33mDense\u001b[0m)       │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m4\u001b[0m)         │      \u001b[38;5;34m5,124\u001b[0m │ global_average_p… │\n",
-       "├─────────────────────┼───────────────────┼────────────┼───────────────────┤\n",
-       "│ class_ids (\u001b[38;5;33mDense\u001b[0m)   │ (\u001b[38;5;45mNone\u001b[0m, \u001b[38;5;34m1\u001b[0m)         │      \u001b[38;5;34m1,281\u001b[0m │ global_average_p… │\n",
-       "└─────────────────────┴───────────────────┴────────────┴───────────────────┘\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">416,613</span> (1.59 MB)\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m416,613\u001b[0m (1.59 MB)\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">6,405</span> (25.02 KB)\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m6,405\u001b[0m (25.02 KB)\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">410,208</span> (1.56 MB)\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m410,208\u001b[0m (1.56 MB)\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "None\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Define the base model and extract features\n",
-    "base_model = tf.keras.applications.MobileNetV2(input_shape=(224, 224, 3), include_top=False, weights='imagenet', alpha=0.35)\n",
-    "base_model.trainable = False  # Freeze the base model\n",
-    "\n",
-    "# Adjust the input layer to ensure compatibility with the 416x416 input size\n",
-    "inputs = tf.keras.layers.Input(shape=(416, 416, 3))\n",
-    "# Resize the input images to 224x224\n",
-    "resized_inputs = tf.keras.layers.Resizing(224, 224)(inputs)\n",
-    "# Normalize the resized inputs\n",
-    "normalized_inputs = resized_inputs / 255.0\n",
-    "x = tf.keras.applications.mobilenet_v2.preprocess_input(normalized_inputs)\n",
-    "x = base_model(x, training=False)\n",
-    "\n",
-    "# Add a global average pooling layer\n",
-    "x = tf.keras.layers.GlobalAveragePooling2D()(x)  # Use `x` instead of `base_model.output`\n",
-    "\n",
-    "# Update the output layer for class predictions to handle binary classification\n",
-    "classes_output = tf.keras.layers.Dense(1, activation='sigmoid', name='class_ids')(x)\n",
-    "\n",
-    "# Define the output layer for bounding box predictions\n",
-    "boxes_output = tf.keras.layers.Dense(4, name='boxes')(x)\n",
-    "\n",
-    "# Create the final model\n",
-    "model = tf.keras.Model(inputs=inputs, outputs=[boxes_output, classes_output])  # Use `inputs` as the input layer\n",
-    "\n",
-    "# Compile the model with binary crossentropy for class predictions\n",
-    "model.name = \"ssd_mobilenet_v2_fpnlite_035_416_int8_frelon\"\n",
-    "model.compile(\n",
-    "    optimizer=tf.keras.optimizers.Adam(learning_rate=0.0001),\n",
-    "    loss={\n",
-    "        'boxes': 'mean_squared_error',\n",
-    "        'class_ids': 'binary_crossentropy'\n",
-    "    },\n",
-    "    metrics={\n",
-    "        'boxes': 'mae',\n",
-    "        'class_ids': 'accuracy'\n",
-    "    }\n",
-    ")\n",
-    "\n",
-    "print(\"Model adapted for predicting bounding boxes and a single class\")\n",
-    "print(model.summary())\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'boxes': array([[185. , 221. , 225. , 271.5]], dtype=float32),\n",
-       " 'class_ids': array([2]),\n",
-       " 'image_id': 0}"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "y_train[0]"
+    "print(f\"TensorFlow version: {tf.__version__}\")\n",
+    "print(f\"tf_keras version: {tf_keras.__version__}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "64e15df2",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (1149,) + inhomogeneous part.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[21], line 4\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[38;5;66;03m# Train the model\u001b[39;00m\n\u001b[0;32m      2\u001b[0m history \u001b[38;5;241m=\u001b[39m model\u001b[38;5;241m.\u001b[39mfit(\n\u001b[0;32m      3\u001b[0m     X_train, \n\u001b[1;32m----> 4\u001b[0m     {\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mboxes\u001b[39m\u001b[38;5;124m'\u001b[39m: \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43marray\u001b[49m\u001b[43m(\u001b[49m\u001b[43m[\u001b[49m\u001b[43my\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mboxes\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mfor\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43my\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43my_train\u001b[49m\u001b[43m]\u001b[49m\u001b[43m)\u001b[49m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mclass_ids\u001b[39m\u001b[38;5;124m'\u001b[39m: np\u001b[38;5;241m.\u001b[39marray([y[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mclass_ids\u001b[39m\u001b[38;5;124m'\u001b[39m] \u001b[38;5;28;01mfor\u001b[39;00m y \u001b[38;5;129;01min\u001b[39;00m y_train])},\n\u001b[0;32m      5\u001b[0m     validation_data\u001b[38;5;241m=\u001b[39m(\n\u001b[0;32m      6\u001b[0m         X_val, \n\u001b[0;32m      7\u001b[0m         {\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mboxes\u001b[39m\u001b[38;5;124m'\u001b[39m: np\u001b[38;5;241m.\u001b[39marray([y[\u001b[38;5;241m0\u001b[39m] \u001b[38;5;28;01mfor\u001b[39;00m y \u001b[38;5;129;01min\u001b[39;00m y_val]), \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mclass_ids\u001b[39m\u001b[38;5;124m'\u001b[39m: np\u001b[38;5;241m.\u001b[39marray([y[\u001b[38;5;241m1\u001b[39m] \u001b[38;5;28;01mfor\u001b[39;00m y \u001b[38;5;129;01min\u001b[39;00m y_val])}\n\u001b[0;32m      8\u001b[0m     ),\n\u001b[0;32m      9\u001b[0m     epochs\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m10\u001b[39m,\n\u001b[0;32m     10\u001b[0m     batch_size\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m32\u001b[39m\n\u001b[0;32m     11\u001b[0m )\n",
-      "\u001b[1;31mValueError\u001b[0m: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (1149,) + inhomogeneous part."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "\n",
-    "# Train the model\n",
-    "history = model.fit(\n",
-    "    X_train, \n",
-    "    {'boxes': np.array([y['boxes'] for y in y_train]), 'class_ids': np.array([y['class_ids'] for y in y_train])},\n",
-    "    validation_data=(\n",
-    "        X_val, \n",
-    "        {'boxes': np.array([y[0] for y in y_val]), 'class_ids': np.array([y[1] for y in y_val])}\n",
-    "    ),\n",
-    "    epochs=10,\n",
-    "    batch_size=32\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To make the 02_train_mobilenet.ipynb notebook functional, I will address the following issues:\n",
-    "\n",
-    "1. **Fix the `ValueError` in the training step**:\n",
-    "   - The error occurs because the labels (`y_train`, `y_val`, etc.) are not properly formatted. I will ensure that the labels are converted into arrays with consistent shapes.\n",
-    "\n",
-    "2. **Ensure preprocessing compatibility**:\n",
-    "   - The input data (`X_train`, `X_val`, `X_test`) must be normalized and resized to the correct dimensions.\n",
-    "\n",
-    "3. **Adjust the `group_labels_by_image_id_and_class_ids` function**:\n",
-    "   - This function will be updated to ensure it outputs tensors with consistent shapes.\n",
-    "\n",
-    "4. **Fix the model training and evaluation steps**:\n",
-    "   - Ensure the model is trained and evaluated without errors.\n",
-    "\n",
-    "Here is the modified code for the notebook:\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "\n",
-    "### Changes Made:\n",
-    "1. **Preprocessing**:\n",
-    "   - Normalized the input images to the range `[0, 1]`.\n",
-    "   - Resized the input images to `224x224` for compatibility with MobileNetV2.\n",
-    "\n",
-    "2. **Label Formatting**:\n",
-    "   - Converted the labels (`y_train`, `y_val`, `y_test`) into arrays with consistent shapes for bounding boxes and class IDs.\n",
-    "\n",
-    "3. **Model Definition**:\n",
-    "   - Used MobileNetV2 as the base model.\n",
-    "   - Added layers for bounding box regression and binary classification.\n",
-    "\n",
-    "4. **Training and Evaluation**:\n",
-    "   - Fixed the training and evaluation steps to use the formatted labels.\n",
-    "\n",
-    "This should resolve the issues and make the notebook functional. Let me know if you encounter further problems!"
+    "# Ensure deterministic behaviour where possible\n",
+    "SEED = 42\n",
+    "np.random.seed(SEED)\n",
+    "tf.random.set_seed(SEED)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
+   "id": "53db2b07",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "Shape (0,) must have rank 2",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[1;32mIn[6], line 34\u001b[0m\n\u001b[0;32m     31\u001b[0m X_test_preprocessed \u001b[38;5;241m=\u001b[39m preprocess_data(X_test)\n\u001b[0;32m     33\u001b[0m \u001b[38;5;66;03m# Group labels by image_id and class_ids\u001b[39;00m\n\u001b[1;32m---> 34\u001b[0m y_train_boxes, y_train_classes, y_train_image_ids \u001b[38;5;241m=\u001b[39m \u001b[43mgroup_labels_by_image_id_and_class_ids\u001b[49m\u001b[43m(\u001b[49m\u001b[43my_train\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mX_train\u001b[49m\u001b[43m)\u001b[49m\n\u001b[0;32m     35\u001b[0m y_val_boxes, y_val_classes, y_val_image_ids \u001b[38;5;241m=\u001b[39m group_labels_by_image_id_and_class_ids(y_val, X_val)\n\u001b[0;32m     37\u001b[0m \u001b[38;5;66;03m# Train the model\u001b[39;00m\n",
-      "Cell \u001b[1;32mIn[6], line 17\u001b[0m, in \u001b[0;36mgroup_labels_by_image_id_and_class_ids\u001b[1;34m(y, X)\u001b[0m\n\u001b[0;32m     14\u001b[0m         grouped_classes\u001b[38;5;241m.\u001b[39mappend(np\u001b[38;5;241m.\u001b[39mzeros((\u001b[38;5;241m1\u001b[39m,), dtype\u001b[38;5;241m=\u001b[39mnp\u001b[38;5;241m.\u001b[39mfloat32))  \u001b[38;5;66;03m# No classes\u001b[39;00m\n\u001b[0;32m     15\u001b[0m     grouped_image_ids\u001b[38;5;241m.\u001b[39mappend(image_id)\n\u001b[0;32m     16\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m (\n\u001b[1;32m---> 17\u001b[0m     \u001b[43mtf\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mragged\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mstack\u001b[49m\u001b[43m(\u001b[49m\u001b[43mgrouped_boxes\u001b[49m\u001b[43m)\u001b[49m,\n\u001b[0;32m     18\u001b[0m     tf\u001b[38;5;241m.\u001b[39mragged\u001b[38;5;241m.\u001b[39mstack(grouped_classes),\n\u001b[0;32m     19\u001b[0m     np\u001b[38;5;241m.\u001b[39marray(grouped_image_ids, dtype\u001b[38;5;241m=\u001b[39mnp\u001b[38;5;241m.\u001b[39mint32)\n\u001b[0;32m     20\u001b[0m )\n",
-      "File \u001b[1;32mc:\\Users\\sBTvR\\miniforge3\\envs\\ml\\lib\\site-packages\\tensorflow\\python\\util\\traceback_utils.py:153\u001b[0m, in \u001b[0;36mfilter_traceback.<locals>.error_handler\u001b[1;34m(*args, **kwargs)\u001b[0m\n\u001b[0;32m    151\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m e:\n\u001b[0;32m    152\u001b[0m   filtered_tb \u001b[38;5;241m=\u001b[39m _process_traceback_frames(e\u001b[38;5;241m.\u001b[39m__traceback__)\n\u001b[1;32m--> 153\u001b[0m   \u001b[38;5;28;01mraise\u001b[39;00m e\u001b[38;5;241m.\u001b[39mwith_traceback(filtered_tb) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m    154\u001b[0m \u001b[38;5;28;01mfinally\u001b[39;00m:\n\u001b[0;32m    155\u001b[0m   \u001b[38;5;28;01mdel\u001b[39;00m filtered_tb\n",
-      "File \u001b[1;32mc:\\Users\\sBTvR\\miniforge3\\envs\\ml\\lib\\site-packages\\tensorflow\\python\\framework\\tensor_shape.py:1107\u001b[0m, in \u001b[0;36mTensorShape.assert_has_rank\u001b[1;34m(self, rank)\u001b[0m\n\u001b[0;32m   1098\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Raises an exception if `self` is not compatible with the given `rank`.\u001b[39;00m\n\u001b[0;32m   1099\u001b[0m \n\u001b[0;32m   1100\u001b[0m \u001b[38;5;124;03mArgs:\u001b[39;00m\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m   1104\u001b[0m \u001b[38;5;124;03m  ValueError: If `self` does not represent a shape with the given `rank`.\u001b[39;00m\n\u001b[0;32m   1105\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[0;32m   1106\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrank \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m (\u001b[38;5;28;01mNone\u001b[39;00m, rank):\n\u001b[1;32m-> 1107\u001b[0m   \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mShape \u001b[39m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m must have rank \u001b[39m\u001b[38;5;132;01m%d\u001b[39;00m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m%\u001b[39m (\u001b[38;5;28mself\u001b[39m, rank))\n",
-      "\u001b[1;31mValueError\u001b[0m: Shape (0,) must have rank 2"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Function to group labels by image_id and class_ids\n",
-    "def group_labels_by_image_id_and_class_ids(y, X):\n",
-    "    grouped_boxes = []\n",
-    "    grouped_classes = []\n",
-    "    grouped_image_ids = []\n",
-    "    for image_id in range(len(X)):  # Assuming X is the reference for the number of images\n",
-    "        \n",
-    "        entry = next((item for item in y if item['image_id'] == image_id), None)\n",
-    "        if entry:\n",
-    "            grouped_boxes.append(np.array(entry['boxes'], dtype=np.float32))\n",
-    "            grouped_classes.append(np.array(entry['class_ids'], dtype=np.float32))\n",
-    "        else:\n",
-    "            grouped_boxes.append(np.zeros((1, 4), dtype=np.float32))  # No boxes\n",
-    "            grouped_classes.append(np.zeros((1,), dtype=np.float32))  # No classes\n",
-    "        grouped_image_ids.append(image_id)\n",
-    "    return (\n",
-    "        tf.ragged.stack(grouped_boxes),\n",
-    "        tf.ragged.stack(grouped_classes),\n",
-    "        np.array(grouped_image_ids, dtype=np.int32)\n",
+    "# Paths and remote resources\n",
+    "NOTEBOOK_DIR = Path.cwd()\n",
+    "DATA_ROOT = NOTEBOOK_DIR / \"hornet-bees-2\"\n",
+    "MODEL_VARIANT = \"st_ssd_mobilenet_v1_025_256\"\n",
+    "MODEL_BASE_URL = (\n",
+    "    \"https://raw.githubusercontent.com/STMicroelectronics/stm32ai-modelzoo/main/\"\n",
+    "    \"object_detection/st_ssd_mobilenet_v1/ST_pretrainedmodel_public_dataset/coco_2017_person\"\n",
+    ")\n",
+    "MODEL_CACHE = NOTEBOOK_DIR / \"models_cache\" / MODEL_VARIANT\n",
+    "MODEL_CACHE.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "MODEL_FILES = {\n",
+    "    \"weights\": f\"{MODEL_VARIANT}.h5\",\n",
+    "    \"config\": f\"{MODEL_VARIANT}_config.yaml\",\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def download_file(url: str, destination: Path) -> Path:\n",
+    "    \"Download a file from a URL if it does not already exist.\"\n",
+    "    if destination.exists():\n",
+    "        return destination\n",
+    "    response = requests.get(url, timeout=60)\n",
+    "    response.raise_for_status()\n",
+    "    destination.write_bytes(response.content)\n",
+    "    return destination\n",
+    "\n",
+    "\n",
+    "def ensure_model_assets() -> Dict[str, Path]:\n",
+    "    \"Retrieve model weights and configuration from the STM32 model zoo.\"\n",
+    "    assets: Dict[str, Path] = {}\n",
+    "    for key, filename in MODEL_FILES.items():\n",
+    "        url = f\"{MODEL_BASE_URL}/{MODEL_VARIANT}/{filename}\"\n",
+    "        path = MODEL_CACHE / filename\n",
+    "        assets[key] = download_file(url, path)\n",
+    "    return assets\n",
+    "\n",
+    "\n",
+    "def parse_input_shape(raw_shape: str) -> Tuple[int, int, int]:\n",
+    "    \"Parse the (H, W, C) tuple stored as a string in the YAML config.\"\n",
+    "    shape = ast.literal_eval(raw_shape)\n",
+    "    if len(shape) != 3:\n",
+    "        raise ValueError(f\"Unexpected input shape {shape}\")\n",
+    "    return tuple(int(dim) for dim in shape)\n",
+    "\n",
+    "\n",
+    "def ensure_materialized_npz(npz_path: Path) -> None:\n",
+    "    \"Validate that Git LFS placeholders have been pulled before loading numpy archives.\"\n",
+    "    if not npz_path.exists():\n",
+    "        raise FileNotFoundError(f\"Expected dataset file missing: {npz_path}\")\n",
+    "    head = npz_path.read_bytes()[:64]\n",
+    "    if b\"version https://git-lfs.github.com\" in head:\n",
+    "        raise RuntimeError(\n",
+    "            f\"{npz_path} is a Git LFS pointer. Run `git lfs pull` or download the FreLon dataset \"\n",
+    "            \"before executing this notebook.\"\n",
+    "        )\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cf8e6dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download assets and instantiate the baseline SSD Mobilenet model\n",
+    "assets = ensure_model_assets()\n",
+    "print(\"Model assets cached:\", assets)\n",
+    "\n",
+    "with assets[\"config\"].open(\"r\", encoding=\"utf-8\") as cfg_file:\n",
+    "    model_config = yaml.safe_load(cfg_file)\n",
+    "\n",
+    "input_shape = parse_input_shape(model_config[\"training\"][\"model\"][\"input_shape\"])\n",
+    "class_names = model_config.get(\"dataset\", {}).get(\"class_names\", [\"hornet\"])\n",
+    "print(f\"Input shape: {input_shape}\")\n",
+    "print(f\"Classes declared in config: {class_names}\")\n",
+    "\n",
+    "# Load the STMicro `.h5` model using the legacy-compatible `tf_keras` loader\n",
+    "st_model = tf_keras.models.load_model(assets[\"weights\"], compile=False)\n",
+    "print(\"Model outputs:\", st_model.output_names)\n",
+    "print(\"Detection heads shapes:\", [output.shape for output in st_model.outputs])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b704973",
+   "metadata": {},
+   "source": [
+    "## Data pipeline helpers\n",
+    "Functions below load the FreLon `.npz` exports, normalise the images, and convert ragged label structures into padded tensors. The padded representation captures bounding boxes, one-hot encoded classes, and a mask marking real boxes versus padding so downstream training code can create dense tensors matching the detection heads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "baebcdfb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_split(split: str) -> Tuple[np.ndarray, List[Dict[str, np.ndarray]]]:\n",
+    "    \"Load images and raw annotations for a given split.\"\n",
+    "    npz_path = DATA_ROOT / f\"{split}_frelon.npz\"\n",
+    "    ensure_materialized_npz(npz_path)\n",
+    "    with np.load(npz_path, allow_pickle=True) as data:\n",
+    "        images = data[\"X\"].astype(np.float32)\n",
+    "        annotations = list(data[\"y\"])\n",
+    "    return images, annotations\n",
+    "\n",
+    "\n",
+    "def normalise_images(images: np.ndarray) -> np.ndarray:\n",
+    "    return images / 255.0\n",
+    "\n",
+    "\n",
+    "def pad_annotations(\n",
+    "    annotations: List[Dict[str, np.ndarray]],\n",
+    "    num_classes: int,\n",
+    ") -> Tuple[np.ndarray, np.ndarray, np.ndarray]:\n",
+    "    \"Convert ragged detection targets into dense arrays.\"\n",
+    "    max_boxes = max(len(entry[\"boxes\"]) for entry in annotations)\n",
+    "    batch_size = len(annotations)\n",
+    "    boxes = np.zeros((batch_size, max_boxes, 4), dtype=np.float32)\n",
+    "    classes = np.zeros((batch_size, max_boxes, num_classes), dtype=np.float32)\n",
+    "    mask = np.zeros((batch_size, max_boxes), dtype=np.float32)\n",
+    "    for idx, entry in enumerate(annotations):\n",
+    "        entry_boxes = np.asarray(entry[\"boxes\"], dtype=np.float32)\n",
+    "        entry_class_ids = np.asarray(entry.get(\"class_ids\", entry.get(\"classes\")), dtype=np.int32)\n",
+    "        count = len(entry_boxes)\n",
+    "        if count == 0:\n",
+    "            continue\n",
+    "        boxes[idx, :count] = entry_boxes\n",
+    "        classes[idx, np.arange(count), entry_class_ids] = 1.0\n",
+    "        mask[idx, :count] = 1.0\n",
+    "    return boxes, classes, mask\n",
+    "\n",
+    "\n",
+    "def summarise_split(name: str, images: np.ndarray, annotations: List[Dict[str, np.ndarray]], num_classes: int) -> None:\n",
+    "    boxes, classes, mask = pad_annotations(annotations, num_classes)\n",
+    "    print(f\"{name} images: {images.shape}\")\n",
+    "    print(f\"{name} boxes tensor shape: {boxes.shape}\")\n",
+    "    print(f\"{name} classes tensor shape: {classes.shape}\")\n",
+    "    print(f\"{name} mask tensor shape: {mask.shape}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07063f94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Attempt to materialise the FreLon dataset splits\n",
+    "try:\n",
+    "    train_images, train_ann = load_split(\"train\")\n",
+    "    val_images, val_ann = load_split(\"val\")\n",
+    "    test_images, test_ann = load_split(\"test\")\n",
+    "    summarise_split(\"Train\", train_images, train_ann, len(class_names))\n",
+    "    summarise_split(\"Validation\", val_images, val_ann, len(class_names))\n",
+    "    summarise_split(\"Test\", test_images, test_ann, len(class_names))\n",
+    "except Exception as error:\n",
+    "    print(f\"Dataset unavailable: {error}\")\n",
+    "    train_images = val_images = test_images = None\n",
+    "    train_ann = val_ann = test_ann = None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2db47e0b",
+   "metadata": {},
+   "source": [
+    "## Fine-tuning workflow (placeholder)\n",
+    "The FreLon data can now be converted into dense tensors, but training requires anchor matching against the SSD detection heads. Implementing that matching logic is outside the scope of this automated refactor. The cell below illustrates where a fine-tuning loop would live once the dataset has been fully materialised and encoded for the SSD outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91ef7871",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if train_images is None:\n",
+    "    raise RuntimeError(\n",
+    "        \"Training cannot start because the FreLon dataset archives were not available. \"\n",
+    "        \"Download the `.npz` files (or run `git lfs pull`) and re-run the data-loading cell.\"\n",
     "    )\n",
     "\n",
-    "# Preprocess the data\n",
-    "def preprocess_data(X):\n",
-    "    # Normalize the images\n",
-    "    X = X / 255.0\n",
-    "    return X[:100]\n",
-    "\n",
-    "# Preprocess the datasets\n",
-    "X_train_preprocessed = preprocess_data(X_train)\n",
-    "X_val_preprocessed = preprocess_data(X_val)\n",
-    "X_test_preprocessed = preprocess_data(X_test)\n",
-    "\n",
-    "# Group labels by image_id and class_ids\n",
-    "y_train_boxes, y_train_classes, y_train_image_ids = group_labels_by_image_id_and_class_ids(y_train, X_train)\n",
-    "y_val_boxes, y_val_classes, y_val_image_ids = group_labels_by_image_id_and_class_ids(y_val, X_val)\n",
-    "\n",
-    "# Train the model\n",
-    "history = model.fit(\n",
-    "    X_train_preprocessed,\n",
-    "    {'boxes': y_train_boxes, 'class_ids': y_train_classes},\n",
-    "    validation_data=(X_val_preprocessed, {\n",
-    "        'boxes': y_val_boxes,\n",
-    "        'class_ids': y_val_classes\n",
-    "    }),\n",
-    "    epochs=10,\n",
-    "    batch_size=32\n",
-    ")\n",
-    "\n",
-    "# Evaluate the model on the test set\n",
-    "y_test_boxes, y_test_classes, y_test_image_ids = group_labels_by_image_id_and_class_ids(y_test, X_test)\n",
-    "test_loss, test_metrics = model.evaluate(\n",
-    "    X_test_preprocessed,\n",
-    "    {'boxes': y_test_boxes, 'class_ids': y_test_classes}\n",
-    ")\n",
-    "\n",
-    "print(\"Test Loss:\", test_loss)\n",
-    "print(\"Test Metrics:\", test_metrics)"
+    "# TODO: Implement SSD anchor matching and compile the model with appropriate losses.\n",
+    "# Placeholder to indicate where fine-tuning would be triggered once targets are aligned with the 6,825 anchors.\n",
+    "# st_model.compile(...)\n",
+    "# history = st_model.fit(...)\n"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "ml",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- replace the old TFLite interpreter logic with helpers that download the ST SSD MobileNet v1 0.25 `.h5` weights and YAML config before loading the model via `tf_keras`
- add utilities that normalise images and pad ragged FreLon annotations into dense box/class/mask tensors ready for SSD-style heads
- gate training behind a dataset-availability check and document the outstanding anchor-matching work needed for full fine-tuning

## Testing
- not run (FreLon `.npz` archives are missing in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0ed2d107c832d923177ba558ac3ed